### PR TITLE
Updates to website documents to be more accurate.

### DIFF
--- a/en/nomination_criteria.md
+++ b/en/nomination_criteria.md
@@ -23,34 +23,7 @@ Here are the currently available nomination status on the server, with their res
 - **Unranked**: Unranked beatmaps use the **question mark icon** in the song selection screen. They don’t offer any leaderboards nor allow the player to gain any performance points from setting scores, their only benefit is to increment a player’s total score. This is the default given status for beatmaps.
 
 # Nomination Criteria
-Here is the currently available nomination criteria for the server. Due to the diversity of game modes, it may differ for each and every one of them.
-
-## What makes a map get ranked?
-- Maps that contain good overall consistency.
-
-## What makes a map get loved?
-- Maps that aren't timed accurately.
-- Maps that blatantly abuse the performance system.
-- Maps with 2B or Aspire aspects. Exceptions can be given:
-  - They can be ranked as long as they don't break the performance or score submission system.
-- Maps that are deemed unrankable but have a lot of traction.
-- Maps with hit objects or invisible sliders that cannot be hit.
-- Maps that are low quality and are deemed to be very low effort.
-- Sets with Difficulty edits. These will vary on the case, for instance:
-  - If a set contains different BPM edits, the original BPM can be ranked while others must be loved. 
-  - If a set contains different AR edits, the highest AR edit can be ranked while others must be loved. 
-
-## What makes a map not get nominated at all?
-- Maps that have official server beatmap nominators. It is best to wait for any updates from their side before requesting them here.
-- Maps that are currently marked as WIP or Pending on the official server. Exceptions can be given:
-  - If you've contacted the mapper and they've confirmed they won't be committing any more changes to the map.
-  - If you're the mapper and you're requesting your own map to be nominated.
-- Maps that include unnecessary derogatory terms, or NSFW (not safe for work) content.
-- Maps that have been submitted without a mapper's authorization.
-- Maps that aren't finished. Exceptions can be given:
-  - If they contain a "proper" beginning and ending.
-- Maps that are an evident copy of other maps.
-- Maps that trigger ScoreV2.
+The nomination criteria may be found [here.](https://docs.google.com/document/d/1s2d7bku_pAtz0Gru8rlhJam7WIYyWMNVM5t1jdPgheM)
 
 ---
 ## Note on current Ranked-Section

--- a/en/restrictions_appeals.md
+++ b/en/restrictions_appeals.md
@@ -80,7 +80,7 @@ It is important to note that emailing the reviews team does not guarantee you wi
 | --------------------------------------- | ----------------- | ------------------------------------------------------------------------------- |
 | Cheating (first offence)                | 3 months          | Full profile wipe is applied                                                    |
 | Cheating (second offence)               | 12 months         | Full profile wipe is applied                                                    |
-| Multi-accounting                        | 2 months          | Cooldown will expand by 1 month for any accounts created after your restriction |
+| Multi-accounting                        | 2 months          | Cooldown will expand by 1 month for any month you make more multiaccounts after |
 | Account Sharing                         | 2 months          | Offending players will be met with a full profile wipe                          |
 | Tablet filter abuse (first offence)     | None              | Profile rollback for scores set                                                 |
 | Tablet filter abuse (second offence)    | 3 months          | Treated as a regular cheating restriction                                       |

--- a/en/restrictions_appeals.md
+++ b/en/restrictions_appeals.md
@@ -82,7 +82,7 @@ It is important to note that emailing the reviews team does not guarantee you wi
 | Cheating (second offence)               | 12 months         | Full profile wipe is applied                                                    |
 | Multi-accounting                        | 2 months          | Cooldown will expand by 1 month for any month you make more multiaccounts after |
 | Account Sharing                         | 2 months          | Offending players will be met with a full profile wipe                          |
-| Tablet filter abuse (first offence)     | None              | Profile rollback for scores set                                                 |
+| Tablet filter abuse (first offence)     | None              | Full standard relax profile wipe                                                |
 | Tablet filter abuse (second offence)    | 3 months          | Treated as a regular cheating restriction                                       |
 
 Any restriction cases not mentioned will usually last 2 months, but this time is not guaranteed and will be reviewed on a case by case basis - you should get in touch if this applies to your case.


### PR DESCRIPTION
It is now a redirect to the Google Doc that the BN team uses for the Beatmap Criteria page. The restriction page has been updated to reflect an internal change to recalculate cooldowns for multi accounting after consulting members of the Account Management team.